### PR TITLE
Add documentation and deprecate RPC XML

### DIFF
--- a/database/kwdb.xml
+++ b/database/kwdb.xml
@@ -4,8 +4,9 @@
 (C) Copyright 2012 Linden Research, Inc.
 (C) Copyright 2013-2023 Sei Lisa.
 (C) Copyright 2017-2023 Mako Nozaki.
-Sei Lisa and Mako Nozaki are the usernames of the authors in the Second Life(R)
-online virtual world.
+(C) Copyright 2023-2023 Alex Carpenter.
+Sei Lisa, Mako Nozaki, and Alex Carpenter are the usernames of the authors in the
+Second Life(R) online virtual world.
 
     LSL2 Keywords Database
 
@@ -85,7 +86,8 @@ Example: grid="os aa"
 <!ATTLIST event
           name CDATA #REQUIRED
           version CDATA #IMPLIED
-          grid NMTOKENS #IMPLIED>
+          grid NMTOKENS #IMPLIED
+          status (normal | deprecated | godmode | unimplemented) "normal">
 <!ELEMENT description (#PCDATA)>
 <!ATTLIST description
           lang NMTOKENS #REQUIRED>
@@ -2123,19 +2125,19 @@ Indicates that this wasn't a valid list entry
     </description>
   </constant>
 
-  <constant name="REMOTE_DATA_CHANNEL" type="integer" value="1">
+  <constant name="REMOTE_DATA_CHANNEL" type="integer" value="1" status="deprecated">
     <description lang="en">
 Value of event_type in remote_event after successful llOpenRemoteDataChannel
     </description>
   </constant>
 
-  <constant name="REMOTE_DATA_REQUEST" type="integer" value="2">
+  <constant name="REMOTE_DATA_REQUEST" type="integer" value="2" status="deprecated">
     <description lang="en">
 Value of event_type in remote_event if XML-RPC request is received
     </description>
   </constant>
 
-  <constant name="REMOTE_DATA_REPLY" type="integer" value="3">
+  <constant name="REMOTE_DATA_REPLY" type="integer" value="3" status="deprecated">
     <description lang="en">
 Value of event_type in remote_event if XML-RPC reply is received
     </description>
@@ -8658,13 +8660,13 @@ If running == TRUE, starts the script with start_param.
   </function>
 
   <!-- This function returns DateTime for Aurora, but we're not special-casing it -->
-  <function name="llOpenRemoteDataChannel" delay="1">
+  <function name="llOpenRemoteDataChannel" delay="1" status="deprecated">
     <description lang="en">
 Creates a channel to listen for XML-RPC calls, and will trigger a remote_data event with channel id once it is available
     </description>
   </function>
 
-  <function name="llSendRemoteData" type="key" delay="3">
+  <function name="llSendRemoteData" type="key" delay="3" status="deprecated">
     <param type="key" name="channel"/>
     <param type="string" name="dest"/>
     <param type="integer" name="idata"/>
@@ -8676,7 +8678,7 @@ Returns a key that is the message_id for the resulting remote_data events.
   </function>
 
   <!-- This function returns DateTime for Aurora, but we're not special-casing it -->
-  <function name="llRemoteDataReply" delay="3">
+  <function name="llRemoteDataReply" delay="3" status="deprecated">
     <param type="key" name="channel"/>
     <param type="key" name="message_id"/>
     <param type="string" name="sdata"/>
@@ -8689,7 +8691,7 @@ Sends an XML-RPC reply to message_id on channel with payload of string sdata and
   <!-- In AuroraSim, this function requires an object type param and returns DateTime.
        We're not adding the Aurora specifics here.
   -->
-  <function name="llCloseRemoteDataChannel" delay="1">
+  <function name="llCloseRemoteDataChannel" delay="1" status="deprecated">
     <param type="key" name="channel"/>
     <description lang="en">
 Closes XML-RPC channel
@@ -13312,7 +13314,7 @@ Triggered various event change the task
     </description>
   </event>
 
-  <event name="remote_data">
+  <event name="remote_data" status="deprecated">
     <param type="integer" name="event_type"/>
     <param type="key"     name="channel"   />
     <param type="key"     name="message_id"/>

--- a/database/kwdb.xml
+++ b/database/kwdb.xml
@@ -98,7 +98,7 @@ Example: grid="os aa"
 
 ]>
 
-<keywords version="0.0.20230409000">
+<keywords version="0.0.20230714000">
   <!--The OpenSim/Aurora functions, constants and types are based on the following revisions:
 
       OpenSim revision 0.9.2.1
@@ -109,7 +109,7 @@ Example: grid="os aa"
   -->
 
   <!-- Grids supported and their versions -->
-  <grid id="sl" version="2023-03-24.579022">Second Life</grid>
+  <grid id="sl" version="2023-06-09.580543">Second Life</grid>
   <grid id="os" version="v0.9.2.1">OpenSimulator</grid>
   <grid id="aa" version="0049c9335f8b91ab119ce4fee5ba1d50d4f6f017">Aurora-Sim</grid>
 
@@ -651,6 +651,12 @@ Returned by llGetAgentInfo if the Agent has 'Always Run' enabled
   <constant name="AGENT_AUTOPILOT" type="integer" value="0x2000" grid="sl os">
     <description lang="en">
 Returned by llGetAgentInfo if the Agent is under autopilot control
+    </description>
+  </constant>
+
+  <constant name="AGENT_AUTOMATED" type="integer" value="0x4000" grid="sl" version="sl:2023-06-09.580543">
+    <description lang="en">
+Returned by llGetAgentInfo if the Agent is marked as a scripted agent/bot.
     </description>
   </constant>
 
@@ -10489,6 +10495,38 @@ Returns an integer indicating whether the RSA signature is valid for msg when us
     <param type="integer" name="count"/>
     <description lang="en">
 Returns a string that is the result of replacing the first count matching instances pattern in src with replacement_pattern.
+    </description>
+  </function>
+
+  <function name="llList2ListSlice" type="list" grid="sl" version="sl:2023-04-03.579248">
+    <param type="list" name="src"/>
+    <param type="integer" name="start"/>
+    <param type="integer" name="end"/>
+    <param type="integer" name="stride"/>
+    <param type="integer" name="slice_index"/>
+    <description lang="en">
+Returns a list of the slice_index'th element of every stride in strided list whose index is a multiple of stride in the range start to end.
+    </description>
+  </function>
+
+  <function name="llListSortStrided" type="list" grid="sl" version="sl:2023-04-03.579248">
+    <param type="list" name="src"/>
+    <param type="integer" name="stride"/>
+    <param type="integer" name="stride_index"/>
+    <param type="integer" name="ascending"/>
+    <description lang="en">
+llListSortStrided is llListSort with the added parameter of stride_index, adding the flexibility to sort by any item in the stride. These routines use the same underlying code and have the same computational complexity.
+    </description>
+  </function>
+
+  <function name="llListFindStrided" type="integer" grid="sl" version="sl:2023-04-03.579248">
+    <param type="list" name="src"/>
+    <param type="list" name="test"/>
+    <param type="integer" name="start"/>
+    <param type="integer" name="end"/>
+    <param type="integer" name="stride"/>
+    <description lang="en">
+Returns the integer index of the first instance of test in src matching conditions.
     </description>
   </function>
 

--- a/database/kwdb.xml
+++ b/database/kwdb.xml
@@ -4458,7 +4458,7 @@ Triggered when a character failed to enter a parcel because it is not allowed to
 
   <constant name="SIM_STAT_PCT_CHARS_STEPPED" type="integer" value="0" grid="sl">
     <description lang="en">
-<!-- TODO: add documentation -->
+ The % of pathfinding characters updated each frame, averaged over the last minute. The value corresponds to the "Characters Updated" stat in the viewer's Statistics Bar.
     </description>
   </constant>
 
@@ -5225,58 +5225,161 @@ Used with llPassTouches to never pass touches to the root.
 
   <!-- These constants' exact appearance version is unknown. The version
        specified is the one where it was first seen by the maintainer. -->
-  <constant name="SIM_STAT_PHYSICS_FPS" type="integer" value="1" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_PHYSICS_FPS" type="integer" value="1" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Physics simulation FPS.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_AGENT_UPDATES" type="integer" value="2" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_AGENT_UPDATES" type="integer" value="2" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Agent updates per second.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_FRAME_MS" type="integer" value="3" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_FRAME_MS" type="integer" value="3" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Total frame time.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_NET_MS" type="integer" value="4" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_NET_MS" type="integer" value="4" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Time spent in 'network' segment of simulation frame.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_OTHER_MS" type="integer" value="5" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_OTHER_MS" type="integer" value="5" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Main simulation segment of frame, encapsulating task, script and misc. updates.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_PHYSICS_MS" type="integer" value="6" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_PHYSICS_MS" type="integer" value="6" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Time spent in 'physics' segment of simulation frame.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_AGENT_MS" type="integer" value="7" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_AGENT_MS" type="integer" value="7" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Time spent in 'agent' segment of simulation frame.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_IMAGE_MS" type="integer" value="8" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_IMAGE_MS" type="integer" value="8" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Time spent in 'image' segment of simulation frame.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_SCRIPT_MS" type="integer" value="9" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_SCRIPT_MS" type="integer" value="9" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Time spent in 'script' segment of simulation frame.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_AGENT_COUNT" type="integer" value="10" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_AGENT_COUNT" type="integer" value="10" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Number of agents in region.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_CHILD_AGENT_COUNT" type="integer" value="11" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_CHILD_AGENT_COUNT" type="integer" value="11" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Number of child (neighboring) agents in region.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_ACTIVE_SCRIPT_COUNT" type="integer" value="12" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_ACTIVE_SCRIPT_COUNT" type="integer" value="12" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Number of active scripts in region.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_PACKETS_IN" type="integer" value="13" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_PACKETS_IN" type="integer" value="13" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Average packets in per second.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_PACKETS_OUT" type="integer" value="14" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_PACKETS_OUT" type="integer" value="14" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Average packets out per second.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_ASSET_DOWNLOADS" type="integer" value="15" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_ASSET_DOWNLOADS" type="integer" value="15" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Pending asset download count.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_ASSET_UPLOADS" type="integer" value="16" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_ASSET_UPLOADS" type="integer" value="16" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Pending asset upload count.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_UNACKED_BYTES" type="integer" value="17" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_UNACKED_BYTES" type="integer" value="17" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Total unacknowledged bytes.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_PHYSICS_STEP_MS" type="integer" value="18" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_PHYSICS_STEP_MS" type="integer" value="18" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Average physics step time.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_PHYSICS_SHAPE_MS" type="integer" value="19" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_PHYSICS_SHAPE_MS" type="integer" value="19" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Average physics 'shape' segment update time.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_PHYSICS_OTHER_MS" type="integer" value="20" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_PHYSICS_OTHER_MS" type="integer" value="20" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Average physics 'other' segment update time.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_SCRIPT_EPS" type="integer" value="21" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_SCRIPT_EPS" type="integer" value="21" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Script events per second.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_SPARE_MS" type="integer" value="22" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_SPARE_MS" type="integer" value="22" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Spare time left after frame.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_SLEEP_MS" type="integer" value="23" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_SLEEP_MS" type="integer" value="23" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Time spent sleeping.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_IO_PUMP_MS" type="integer" value="24" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_IO_PUMP_MS" type="integer" value="24" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ PumpIO time.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_SCRIPT_RUN_PCT" type="integer" value="25" grid="sl" version="sl:2023-03-24.579022"/>
+  <constant name="SIM_STAT_SCRIPT_RUN_PCT" type="integer" value="25" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Percent of scripts run during frame.
+    </description>
+  </constant>
 
-  <constant name="SIM_STAT_AI_MS" type="integer" value="26" grid="sl" version="sl:2023-03-24.579022"/>
-
+  <constant name="SIM_STAT_AI_MS" type="integer" value="26" grid="sl" version="sl:2023-03-24.579022">
+    <description lang="en">
+ Time spent on AI step. 
+    </description>
+  </constant>
 
   <!-- String constants -->
 
@@ -10353,12 +10456,18 @@ str2 repeats if it is shorter than str1.
     <param type="string" name="authkey"/>
     <param type="string" name="message"/>
     <param type="string" name="hashalg"/>
+    <description lang="en">
+Returns a string that is the Base64-encoded HMAC hash of msg when using hash algorithm algorithm and secret key private_key. This function supports md5, sha1, sha224, sha256, sha384, sha512 for algorithm.
+    </description>
   </function>
 
   <function name="llSignRSA" type="string" grid="sl" version="sl:2023-02-21.578370">
     <param type="string" name="privkey"/>
     <param type="string" name="message"/>
     <param type="string" name="hashalg"/>
+    <description lang="en">
+Returns a string that is the Base64-encoded RSA signature of msg when using hash algorithm algorithm and secret key private_key. Can be paired with llVerifyRSA to pass verifiable messages. This function supports md5, sha1, sha224, sha256, sha384, sha512 for algorithm.
+    </description>
   </function>
 
   <function name="llVerifyRSA" type="integer" grid="sl" version="sl:2023-02-21.578370">
@@ -10366,6 +10475,9 @@ str2 repeats if it is shorter than str1.
     <param type="string" name="message"/>
     <param type="string" name="signature"/>
     <param type="string" name="hashalg"/>
+    <description lang="en">
+Returns an integer indicating whether the RSA signature is valid for msg when using hash algorithm algorithm and public RSA key public_key. Returns TRUE if the signature is verified, and FALSE otherwise. Can be paired with llSignRSA to validate the authenticity of messages from other LSL scripts. This function supports md5, sha1, sha224, sha256, sha384, sha512 for algorithm.
+    </description>
   </function>
 
   <!-- This function's exact appearance version is unknown. The version
@@ -10375,6 +10487,9 @@ str2 repeats if it is shorter than str1.
     <param type="string" name="search"/>
     <param type="string" name="replace"/>
     <param type="integer" name="count"/>
+    <description lang="en">
+Returns a string that is the result of replacing the first count matching instances pattern in src with replacement_pattern.
+    </description>
   </function>
 
   <!-- OpenSim/Aurora-specific functions -->


### PR DESCRIPTION
* Adds documentation to latest batch of LSL additions.
* Deprecate RPC XML due to https://community.secondlife.com/blogs/entry/13007-shutting-down-lsl-xml-rpc/